### PR TITLE
Make gpg key location and fingerprint configurable

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -19,7 +19,7 @@ class elastic_stack::repo (
   Integer           $version       = 7,
   Optional[String]  $base_repo_url = undef,
   Optional[String]  $key_source    = 'https://artifacts.elastic.co/GPG-KEY-elasticsearch',
-  Optional[String]  $key_id        = '46095ACC8548582C1A2699A9D27D666CD88E42B4',  
+  Optional[String]  $key_id        = '46095ACC8548582C1A2699A9D27D666CD88E42B4',
 ) {
   if $prerelease {
     $version_suffix = '.x-prerelease'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,6 +18,8 @@ class elastic_stack::repo (
   String            $proxy         = 'absent',
   Integer           $version       = 7,
   Optional[String]  $base_repo_url = undef,
+  Optional[String]  $key_source    = 'https://artifacts.elastic.co/GPG-KEY-elasticsearch',
+  Optional[String]  $key_id        = '46095ACC8548582C1A2699A9D27D666CD88E42B4',  
 ) {
   if $prerelease {
     $version_suffix = '.x-prerelease'
@@ -60,8 +62,6 @@ class elastic_stack::repo (
   }
 
   $base_url = "${_repo_url}/${version_prefix}${version}${version_suffix}/${_repo_path}"
-  $key_id='46095ACC8548582C1A2699A9D27D666CD88E42B4'
-  $key_source='https://artifacts.elastic.co/GPG-KEY-elasticsearch'
   $description='Elastic package repository.'
 
   case $::osfamily {


### PR DESCRIPTION
For a completely internal deployment, downloading the repository key directly
from the internet is not an option. This change makes the $key_source and
$key_id variables configurable so an internal mirror can be used.