### PR TITLE
Drop yumrepo_core from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,10 +19,6 @@
     {
       "name": "puppet/yum",
       "version_requirement": ">= 0.9.6 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs/yumrepo_core",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
the core modules are vendored into the agent and dont need to be listed
in the metadata.json

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
