### PR TITLE
added yumrepo_core to the dependencies,

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "puppet/yum",
       "version_requirement": ">= 0.9.6 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs/yumrepo_core",
+      "version_requirement": ">= 1.1.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION

#### Pull Request (PR) description
since puppet 6 there is no more yumrepo resource in puppet. i added the yumrepo_core to dependencies.so the module can work with puppet 6 and up.
