### PR TITLE
Add elastic_stack_keystore resource to handle keystore files for both elasticsearch and kibana

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,6 +8,10 @@
 
 * [`elastic_stack::repo`](#elastic_stack--repo): Set up the package repository for Elastic Stack components
 
+### Resource types
+
+* [`elastic_stack_keystore`](#elastic_stack_keystore): Manages a keystore settings file (for either Elasticserach or Kibana service.
+
 ## Classes
 
 ### <a name="elastic_stack--repo"></a>`elastic_stack::repo`
@@ -80,4 +84,62 @@ Data type: `Optional[String]`
 The base url for the repo path
 
 Default value: `undef`
+
+## Resource types
+
+### <a name="elastic_stack_keystore"></a>`elastic_stack_keystore`
+
+Manages a keystore settings file (for either Elasticserach or Kibana service.
+
+#### Properties
+
+The following properties are available in the `elastic_stack_keystore` type.
+
+##### `ensure`
+
+Valid values: `present`, `absent`
+
+The basic property that the resource should be in.
+
+Default value: `present`
+
+##### `password`
+
+Password to protect keystore.
+
+Default value: `''`
+
+##### `settings`
+
+A key/value hash of settings names and values.
+
+#### Parameters
+
+The following parameters are available in the `elastic_stack_keystore` type.
+
+* [`provider`](#-elastic_stack_keystore--provider)
+* [`purge`](#-elastic_stack_keystore--purge)
+* [`service`](#-elastic_stack_keystore--service)
+
+##### <a name="-elastic_stack_keystore--provider"></a>`provider`
+
+The specific backend to use for this `elastic_stack_keystore` resource. You will seldom need to specify this --- Puppet
+will usually discover the appropriate provider for your platform.
+
+##### <a name="-elastic_stack_keystore--purge"></a>`purge`
+
+Valid values: `true`, `false`, `yes`, `no`
+
+Whether to proactively remove settings that exist in the keystore but
+are not present in this resource's settings.
+
+Default value: `false`
+
+##### <a name="-elastic_stack_keystore--service"></a>`service`
+
+Valid values: `elasticsearch`, `kibana`
+
+Service that manages the keystore (either "elasticsearch" or "kibana").
+
+Default value: `elasticsearch`
 

--- a/lib/puppet/provider/elastic_stack_keystore/ruby.rb
+++ b/lib/puppet/provider/elastic_stack_keystore/ruby.rb
@@ -1,0 +1,345 @@
+# frozen_string_literal: true
+
+Puppet::Type.type(:elastic_stack_keystore).provide(
+  :elastic_stack_keystore
+) do
+  desc 'Provider for both `elasticsearch-keystore` and `kibana-keystore` based secret management.'
+
+  mk_resource_methods
+
+  def self.defaults_dir
+    @defaults_dir ||= case Facter.value('osfamily')
+                      when 'RedHat'
+                        '/etc/sysconfig'
+                      else
+                        '/etc/default'
+                      end
+  end
+
+  def self.root_dir
+    @root_dir ||= case Facter.value('osfamily')
+                  when 'OpenBSD'
+                    '/usr/local'
+                  else
+                    '/usr/share'
+                  end
+  end
+
+  def self.home_dir_kibana
+    @home_dir_kibana ||= File.join(root_dir, 'kibana')
+  end
+
+  def self.home_dir_elasticsearch
+    @home_dir_elasticsearch ||= File.join(root_dir, 'elasticsearch')
+  end
+
+  def self.elastic_keystore_password_file
+    keystore_env = get_envvar('elasticsearch', 'ES_KEYSTORE_PASSPHRASE_FILE')
+    if keystore_env.empty?
+      @elastic_keystore_password_file ||= "#{configdir('elasticsearch')}/.elasticsearch-keystore-password"
+    else
+      @elastic_keystore_password_file ||= keystore_env 
+    end
+  end
+
+  def self.elastic_keystore_password(password = '')
+    if File.file?(elastic_keystore_password_file)
+      @elastic_keystore_password ||= File.open(elastic_keystore_password_file, &:readline).strip
+    else
+      @elastic_keystore_password = password.empty? ? @elastic_keystore_password : password
+    end
+  end
+
+  def self.elastic_keystore_password_file_bak
+    @elastic_keystore_password_file_bak ||= "#{elastic_keystore_password_file}.puppet-bak"
+  end
+
+  def self.elastic_keystore_password_bak
+    if File.file?(elastic_keystore_password_file_bak)
+      @elastic_keystore_password_bak ||= File.open(elastic_keystore_password_file_bak, &:readline).strip
+    else
+      @elastic_keystore_password_bak ||= ''
+    end
+  end
+
+  attr_accessor :defaults_dir, :root_dir, :home_dir_kibana, :home_dir_elasticsearch, :elastic_keystore_password_file, :elastic_keystore_password, :elastic_keystore_password_file_bak, :elastic_keystore_password_bak
+
+  optional_commands kibana_keystore: "#{home_dir_kibana}/bin/kibana-keystore"
+  optional_commands elasticsearch_keystore: "#{home_dir_elasticsearch}/bin/elasticsearch-keystore"
+
+  def self.run_keystore(args, service, stdin = nil)
+    options = {
+      uid: service.to_s,
+      gid: service.to_s,
+      failonfail: true
+    }
+
+    password = case service
+               when "elasticsearch"
+                 File.file?(elastic_keystore_password_file_bak) ? elastic_keystore_password_bak : elastic_keystore_password
+               else
+                 ''
+               end
+
+    cmd = [command("#{service}_keystore")]
+    if args[0] == "create" || args[0] == "has-passwd"
+      options[:failonfail] = false
+      options[:combine] = true
+    elsif args[0] == "passwd"
+      options[:combine] = true
+      if File.file?(elastic_keystore_password_file_bak)
+        stdin = "#{elastic_keystore_password_bak}\n#{elastic_keystore_password}\n#{elastic_keystore_password}"
+      else
+        stdin = "#{elastic_keystore_password}\n#{elastic_keystore_password}"
+      end
+    end
+
+    if service == "elasticsearch"
+      unless args[0] == "passwd" || args[0] == "has-passwd"
+        if has_passwd?(service)
+          unless password.strip.empty?
+            if stdin.nil?
+              stdin = "#{password}"
+            else
+              stdin = "#{password}\n#{stdin}"
+            end
+          end
+        end
+      end
+    end
+
+    unless stdin.nil?
+      stdinfile = Tempfile.new("#{service}-keystore")
+      stdinfile << stdin
+      stdinfile.flush
+      options[:stdinfile] = stdinfile.path
+    end
+
+    begin
+      stdout = execute(cmd + args, options)
+    ensure
+      unless stdin.nil?
+        stdinfile.close
+        stdinfile.unlink
+      end
+    end
+
+    if stdout.exitstatus.zero?
+      stdout
+    else
+      options[:failonfail] ? raise(Puppet::Error, stdout) : stdout
+    end
+  end
+
+  def self.present_keystores(configdir, service, password = '')
+    keystore_file = File.join(configdir, "#{service}.keystore")
+    if File.file?(keystore_file)
+      current_password = case service
+                         when "elasticsearch"
+                           if has_passwd?(service)
+			     File.file?(elastic_keystore_password_file_bak) ? elastic_keystore_password_bak : elastic_keystore_password(password.value)
+                           else
+			     elastic_keystore_password(password.value)
+                             ''
+                           end
+                         else
+                           ''
+                         end
+      settings = {}
+      run_keystore(['list'], service).split("\n").each do |setting|
+        if service == "kibana"
+          settings[setting] = ''
+        else
+          settings[setting] = run_keystore(['show', setting], service)
+        end
+      end
+      [{
+        name: service,
+        ensure: :present,
+        provider: name,
+        settings: settings,
+        password: current_password,
+      }]
+    else
+      []
+    end
+  end
+
+  def self.configdir(service)
+    dir = get_envvar(service, '(ES|KBN)_PATH_CONF')
+    if dir.empty?
+      File.join("/etc", service)
+    else      
+      dir
+    end
+  end
+
+  def self.get_envvar(service, env)
+    defaults_file = File.join(defaults_dir, service)
+    val = ''
+    if File.file?(defaults_file)
+      File.readlines(defaults_file).each do |line|
+        next if line =~ /^#/
+        key,value = line.split "="
+        if key =~ /#{env}/
+          val = value.gsub(/"/, '').strip
+        end
+      end
+    end
+    val
+  end
+
+  def self.instances(password = '')
+    keystores = []
+    ['kibana','elasticsearch'].each do |service|
+      keystores = keystores.concat(present_keystores(configdir(service), service, password))
+    end
+    keystores.map do |keystore|
+      new keystore
+    end
+  end
+
+  def self.has_passwd?(service)
+    has_passwd = run_keystore(['has-passwd'], service).split("\n").last
+    has_passwd.match? /^Keystore is password-protected/
+  end
+
+  def self.keystore_password_management(service)
+    if has_passwd?(service)
+      unless elastic_keystore_password_bak.strip.empty?
+        run_keystore(['passwd'], service) if elastic_keystore_password != elastic_keystore_password_bak
+      end
+    else
+      run_keystore(['passwd'], service) unless elastic_keystore_password.empty?
+    end
+  end
+
+  def self.prefetch(resources)
+    password = resources.key?(:elasticsearch) ? resources[:elasticsearch].parameters[:password] : ''
+    keystores = instances(password)
+    resources.each_key do |name|
+      provider = keystores.find { |keystore| keystore.name.to_sym == name }
+      resources[name].provider = provider if provider
+    end
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  def flush
+    configdir = self.class.configdir(resource[:service].to_s)
+    service = resource[:service].to_s
+
+    case @property_flush[:ensure]
+    when :present
+      debug(self.class.run_keystore(['create', '-s'], service, 'N'))
+      @property_flush[:settings] = resource[:settings]
+    when :absent
+      File.delete(File.join([
+                              configdir, "#{resource[:service]}.keystore"
+                            ]))
+      return
+    end
+
+    # Note that since the property is :array_matching => :all, we have to
+    # expect that the hash is wrapped in an array.
+    if @property_flush.key?(:settings) && !(@property_flush[:settings].empty? && @property_hash.nil? && @property_hash[:settings].nil?)
+      # Flush properties that _should_ be present
+      @property_flush[:settings].each do |setting, value|
+        next if @property_hash.key?(:settings) && @property_hash[:settings].key?(setting) \
+          && @property_hash[:settings][setting] == value
+
+        args = ['add', '--force']
+        args << '--stdin' if service == "kibana"
+        args << setting
+        debug(self.class.run_keystore(args, service, value))
+      end
+
+      # Remove properties that are no longer present
+      if resource[:purge]
+        (@property_hash[:settings].keys.sort - @property_flush[:settings].keys.sort).each do |setting|
+          debug(self.class.run_keystore(
+                  ['remove', setting], service 
+                ))
+        end
+      end
+    end
+
+    keystore_settings = self.class.run_keystore(['list'], service).split("\n").each do |setting|
+      settings = {}
+      if service == "kibana"
+        settings[setting] = ''
+      else
+        settings[setting] = self.class.run_keystore(['show', setting], service)
+      end
+      settings
+    end
+
+    # if service == "elasticsearch" && @property_flush.key?(:password)
+    if service == "elasticsearch"
+      # set and update keystore password if needed
+      self.class.keystore_password_management(service)
+      # unlink backup file containing keystore password (synced)
+      File.unlink(self.class.elastic_keystore_password_file_bak) if File.file?(self.class.elastic_keystore_password_file_bak)
+    end
+
+    @property_hash = {
+      name: service,
+      ensure: :present,
+      provider: resource[:name],
+      settings: keystore_settings,
+      password: self.class.elastic_keystore_password,
+    }
+  end
+
+  # settings property setter
+  #
+  # @return [Hash] settings
+  def settings=(new_settings)
+    @property_flush[:settings] = new_settings
+  end
+
+  # settings property getter
+  #
+  # @return [Hash] settings
+  def settings
+    @property_hash[:settings]
+  end
+
+  # settings property setter
+  #
+  # @return [String] password
+  def password=(new_password)
+    @property_flush[:password] = new_password
+  end
+
+  # settings property getter
+  #
+  # @return [Hash] password
+  def password
+    @property_hash[:password]
+  end
+
+  # Sets the ensure property in the @property_flush hash.
+  #
+  # @return [Symbol] :present
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  # Determine whether this resource is present on the system.
+  #
+  # @return [Boolean]
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  # Set flushed ensure property to absent.
+  #
+  # @return [Symbol] :absent
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+end

--- a/lib/puppet/type/elastic_stack_keystore.rb
+++ b/lib/puppet/type/elastic_stack_keystore.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: false
+
+require 'puppet/parameter/boolean'
+
+Puppet::Type.newtype(:elastic_stack_keystore) do
+  desc 'Manages a keystore settings file (for either Elasticserach or Kibana service.'
+
+  ensurable
+
+  newparam(:service, namevar: true) do
+    desc 'Service that manages the keystore (either "elasticsearch" or "kibana").'
+    newvalues(:elasticsearch, :kibana)
+    defaultto 'elasticsearch'
+  end
+
+  newparam(:purge, boolean: true, parent: Puppet::Parameter::Boolean) do
+    desc <<-EOS
+      Whether to proactively remove settings that exist in the keystore but
+      are not present in this resource's settings.
+    EOS
+
+    defaultto false
+  end
+
+  newproperty(:password) do
+    desc 'Password to protect keystore.'
+
+    defaultto ''
+
+    def insync?(value)
+      if resource[:service].to_s == 'kibana'
+        true
+      else
+        value == @should.first
+      end
+    end
+  end
+
+  newproperty(:settings) do
+    desc 'A key/value hash of settings names and values.'
+
+    # The keystore utility can only retrieve a list of stored settings,
+    # so here we only compare the existing settings (sorted) with the
+    # desired settings' keys
+    def insync?(value)
+      if resource[:service].to_s == 'kibana'
+        if resource[:purge]
+          value.keys.sort == @should.first.keys.sort
+        else
+          (@should.first.keys.sort - value.keys.sort).empty?
+        end
+      else
+        if resource[:purge]
+          #value.sort == @should.first.keys.sort
+          value == @should.first
+        else
+          if (@should.first.keys.sort - value.keys.sort).empty?
+            # compare the values of keys in common
+            (@should.first.values.sort - value.values.sort).empty?
+          else
+            false
+          end
+        end
+      end
+    end
+
+    def is_to_s(value)
+      debug("into is_to_s #{value}")
+      # hide sensitive data
+      value.map { |k,v| [k, "xxxx"] }.to_h.inspect
+    end
+
+    def should_to_s(value)
+      debug("into should_to_s #{value}")
+      # hide sensitive data
+      value.map { |k,v| [k, "xxxx"] }.to_h.inspect
+    end
+
+    def change_to_s(currentvalue, newvalue)
+      ret = ''
+
+      added_settings = newvalue.keys - currentvalue.keys
+      ret << "added: #{added_settings.join(', ')} " unless added_settings.empty?
+
+      removed_settings = currentvalue.keys - newvalue.keys
+      unless removed_settings.empty?
+        ret << if resource[:purge]
+                 "removed: #{removed_settings.join(', ')} "
+               else
+                 "would have removed: #{removed_settings.join(', ')}, but purging is disabled "
+               end
+      end
+
+      changed = newvalue.map { |k,v| currentvalue[k] == v ? nil : k }.compact
+      ret << "changed: #{changed.join(', ')}" unless changed.empty?
+
+      ret
+    end
+  end
+
+  autorequire(:augeas) do
+    "defaults_#{self[:name]}"
+  end
+end


### PR DESCRIPTION
Hello,

I needed to install Elasticsearch version 8 (with Kibana).
I had several problems configuring the keystore files (elasticsearch and kibana) using the `puppet-elasticsearch` and `puppet-kibana` modules.

Here are the problems encountered:
- execution of the `elasticsearch_keystore` resource is not indempotent. It recreates the keystore file each time it is run, whether or not there has been a change. It does not parse the contents to ensure that the file is synchronized;
- if the keystore file already exists, it tries to create it again, which generates an error;
- there is no possibility of protecting the keystore file with a password;
- diff does not allow changes to be viewed;
- the kibana module does not manage keystore files.

I thought it simpler to implement a single resource type to manage the keystore in the `puppet-elastic_stack` module (to be used by both the elasticsearch and kibana modules). This avoids duplicate code.
I used the `elasticsearch_keystore` resource to correct the problems encountered and added keystore management for Kibana. I didn't keep the notion of instances, which weren't necessarily of interest in my case.

Example of the `elastic_stack_keystore` resource declaration for Elasticsearch:
```
elastic_stack_keystore { 'elasticsearch_secrets':
  service     => 'elasticsearch',
  purge       => false,
  password => Sensitive($password),
  settings    => { .. },
}
```

To manage the keystore password, there are 2 modes:
- If the keystore file is not password-protected and the `password` parameter is set and not empty, when the resource is executed, the keystore will be password-protected. However, it will not be possible to re-modify it by changing the `password` parameter (this will have to be done manually on the target).
- Possibility of managing a file containing the password on the target, enabling the `password` parameter to be changed without having to do so manually. To do this, declare a resource file containing the (with the `backup` parameter set to true).
  I haven't included all the code in the elasticsearch module, just an example to illustrate.
  ```
    unless $elasticsearch::elasticsearch_keystore_password =~ Undef {
      file { $elasticsearch::elasticsearch_keystore_password_path:
        ensure  => 'file',
        group   => $elasticsearch::elasticsearch_group,
        owner   => $elasticsearch::elasticsearch_user,
        mode    => '0660',
        content => $_elasticsearch_keystore_password,
        backup  => true,
      }
    }

    unless $elasticsearch::secrets =~ Undef {
      file { "${elasticsearch::configdir}/elasticsearch.keystore":
        owner => $elasticsearch::elasticsearch_user,
      }
      elastic_stack_keystore { 'elasticsearch_secrets':
        service     => 'elasticsearch',
        purge       => $elasticsearch::purge_secrets,
        settings    => $elasticsearch::secrets,
        password => $_elasticsearch_keystore_password,
        notify        => $elasticsearch::_notify_service,
        require      => File["${elasticsearch::configdir}/elasticsearch.keystore"],
      }
   }
  ```

Example of the `elastic_stack_keystore` resource declaration for Kibana (kibana-keystore does not support password):
```
elastic_stack_keystore { 'kibana_secrets':
  service     => 'kibana',
  purge       => false,
  settings    => { .. },
```

The `service` parameter is the namevar and can take 2 values: `elasticsearch` or `kibana`.