### PR TITLE
Move to apt keyrings because apt-key is deprecated since Debian11

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -68,21 +68,18 @@ class elastic_stack::repo (
     'Debian': {
       include apt
 
+      apt::keyring { 'elastic.gpg':
+        source => $key_source,
+      }
+
       apt::source { 'elastic':
-        ensure   => 'present',
         comment  => $description,
         location => $base_url,
         release  => 'stable',
         repos    => 'main',
-        key      => {
-          'id'     => $key_id,
-          'source' => $key_source,
-        },
-        include  => {
-          'deb' => true,
-          'src' => false,
-        },
+        keyring  => '/etc/apt/keyrings/elastic.gpg',
         pin      => $priority,
+        require  => Apt::Keyring['elastic.gpg'],
       }
     }
     'RedHat', 'Linux': {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
This uses apt keyring for the repository instead of the deprecated apt-key mechanism. 
-->

#### This Pull Request (PR) fixes the following issues
<!--
Fixes deprecation of apt-key starting from Debian 13. 
-->
