### PR TITLE
Move old changelog to history.md

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,123 @@
+## [7.0.0](https://github.com/voxpupuli/puppet-elastic_stack/tree/7.0.0) (2019-08-13)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.3.2...7.0.0)
+
+**Merged pull requests:**
+
+- Default to Elastic Stack version 7 [\#26](https://github.com/voxpupuli/puppet-elastic_stack/pull/26) ([ghost](https://github.com/ghost))
+
+## [6.3.2](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.3.2) (2019-08-13)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.3.1...6.3.2)
+
+**Closed issues:**
+
+- r10k continuously updating elastic\_stack [\#19](https://github.com/voxpupuli/puppet-elastic_stack/issues/19)
+
+**Merged pull requests:**
+
+- Release 6.3.2 [\#31](https://github.com/voxpupuli/puppet-elastic_stack/pull/31) ([ghost](https://github.com/ghost))
+- Do not pass facterversion to on\_supported\_os [\#30](https://github.com/voxpupuli/puppet-elastic_stack/pull/30) ([ghost](https://github.com/ghost))
+- Update metadata versions [\#28](https://github.com/voxpupuli/puppet-elastic_stack/pull/28) ([pillarsdotnet](https://github.com/pillarsdotnet))
+
+## [6.3.1](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.3.1) (2019-04-17)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.2.4...6.3.1)
+
+**Closed issues:**
+
+- Current release tarball 6.2.4 erroneously contains local `.git` directory [\#24](https://github.com/voxpupuli/puppet-elastic_stack/issues/24)
+
+**Merged pull requests:**
+
+- Support Puppet 6 [\#25](https://github.com/voxpupuli/puppet-elastic_stack/pull/25) ([ghost](https://github.com/ghost))
+
+## [6.2.4](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.2.4) (2018-09-16)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.2.3...6.2.4)
+
+**Merged pull requests:**
+
+- Allow puppetlabs-apt 6.x and newer [\#17](https://github.com/voxpupuli/puppet-elastic_stack/pull/17) ([jhooyberghs](https://github.com/jhooyberghs))
+
+## [6.2.3](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.2.3) (2018-08-28)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.2.2...6.2.3)
+
+## [6.2.2](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.2.2) (2018-08-27)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.2.1...6.2.2)
+
+**Closed issues:**
+
+- Support stdlib 5 [\#15](https://github.com/voxpupuli/puppet-elastic_stack/issues/15)
+
+**Merged pull requests:**
+
+- Allow the use of stdlib version 5 [\#16](https://github.com/voxpupuli/puppet-elastic_stack/pull/16) ([ghost](https://github.com/ghost))
+
+## [6.2.1](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.2.1) (2018-08-14)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.2.0...6.2.1)
+
+**Closed issues:**
+
+- Allow $version to set an specific release  [\#13](https://github.com/voxpupuli/puppet-elastic_stack/issues/13)
+- kibana packages not found in oss repository [\#10](https://github.com/voxpupuli/puppet-elastic_stack/issues/10)
+
+**Merged pull requests:**
+
+- Update puppetlabs/apt dependency [\#14](https://github.com/voxpupuli/puppet-elastic_stack/pull/14) ([l-lotz](https://github.com/l-lotz))
+
+## [6.2.0](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.2.0) (2018-07-17)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.1.0...6.2.0)
+
+**Closed issues:**
+
+- release consistency [\#11](https://github.com/voxpupuli/puppet-elastic_stack/issues/11)
+- repo\_url parameter [\#8](https://github.com/voxpupuli/puppet-elastic_stack/issues/8)
+
+**Merged pull requests:**
+
+- Add base\_repo\_url parameter [\#12](https://github.com/voxpupuli/puppet-elastic_stack/pull/12) ([baurmatt](https://github.com/baurmatt))
+
+## [6.1.0](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.1.0) (2018-05-31)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.0.1...6.1.0)
+
+**Closed issues:**
+
+- Priority parameter should be undef by default [\#5](https://github.com/voxpupuli/puppet-elastic_stack/issues/5)
+- apt::update ordering creates dependency cycles [\#4](https://github.com/voxpupuli/puppet-elastic_stack/issues/4)
+- update Project URL on Puppet Forge and changelog [\#1](https://github.com/voxpupuli/puppet-elastic_stack/issues/1)
+
+**Merged pull requests:**
+
+- Support 6.3 OSS repositories [\#9](https://github.com/voxpupuli/puppet-elastic_stack/pull/9) ([tylerjl](https://github.com/tylerjl))
+- Support for 2.x-style Repository URLs [\#7](https://github.com/voxpupuli/puppet-elastic_stack/pull/7) ([tylerjl](https://github.com/tylerjl))
+- Change default of priority from 10 to undef [\#6](https://github.com/voxpupuli/puppet-elastic_stack/pull/6) ([baurmatt](https://github.com/baurmatt))
+
+## [6.0.1](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.0.1) (2017-12-07)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/6.0.0...6.0.1)
+
+**Closed issues:**
+
+- Do not use cross module variables [\#2](https://github.com/voxpupuli/puppet-elastic_stack/issues/2)
+
+## [6.0.0](https://github.com/voxpupuli/puppet-elastic_stack/tree/6.0.0) (2017-11-14)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/0.2.1...6.0.0)
+
+## [0.2.1](https://github.com/voxpupuli/puppet-elastic_stack/tree/0.2.1) (2017-11-13)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/0.2.0...0.2.1)
+
+## [0.2.0](https://github.com/voxpupuli/puppet-elastic_stack/tree/0.2.0) (2017-11-10)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-elastic_stack/compare/5cfd57919eb0116c82d76a782697e02d7d93604d...0.2.0)
+
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*


### PR DESCRIPTION
#### Pull Request (PR) description
Add HISTORY.md to prevent new releases from changing old changlog entries.