### PR TITLE
manage gpg key with apt::keyring

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -34,6 +34,7 @@ The following parameters are available in the `elastic_stack::repo` class:
 * [`base_repo_url`](#-elastic_stack--repo--base_repo_url)
 * [`gpg_key_source`](#-elastic_stack--repo--gpg_key_source)
 * [`apt_keyring_name`](#-elastic_stack--repo--apt_keyring_name)
+* [`apt_keyring_dir`](#-elastic_stack--repo--apt_keyring_dir)
 
 ##### <a name="-elastic_stack--repo--oss"></a>`oss`
 
@@ -100,4 +101,12 @@ The filename extention is important here.
 Use `.asc` if the key is armored and `.gpg` if it's unarmored
 
 Default value: `'elastic-keyring.asc'`
+
+##### <a name="-elastic_stack--repo--apt_keyring_dir"></a>`apt_keyring_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+The path where the GPG key should be stored (APT only)
+
+Default value: `'/etc/apt/keyrings'`
 

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -38,8 +38,10 @@ describe 'elastic_stack::repo', type: 'class' do
       case facts[:os]['family']
       when 'Debian'
         it { is_expected.to declare_apt }
+        it { is_expected.to contain_apt__keyring('elastic-keyring.asc') }
       when 'RedHat'
         it { is_expected.to declare_yum }
+        it { is_expected.to contain_exec('elastic_yumrepo_yum_clean') }
       when 'Suse'
         it { is_expected.to declare_zypper }
         it { is_expected.to contain_exec('elastic_suse_import_gpg').with(command: rpm_key_cmd) }


### PR DESCRIPTION
Fixes
```
W: https://artifacts.elastic.co/packages/7.x/apt/dists/stable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```
